### PR TITLE
Add roam-link company completion

### DIFF
--- a/company-org-roam.el
+++ b/company-org-roam.el
@@ -72,24 +72,34 @@ A value of nil means the caches never expire."
 
 (defun company-org-roam--post-completion (title)
   "The post-completion action for `company-org-roam'.
-It deletes the inserted TITLE, and replaces it with a relative
-file link.
+If completing an org file link, it deletes the inserted TITLE, and
+replaces it with a relative file link. The completion inserts the
+absolute file path where the buffer does not have a corresponding file.
 
-The completion inserts the absolute file path where the buffer
-does not have a corresponding file."
-  (let* ((cache (gethash (file-truename org-roam-directory) company-org-roam-cache))
-         (path (gethash title cache))
-         (current-file-path (-> (or (buffer-base-buffer)
-                                    (current-buffer))
-                                (buffer-file-name)
-                                (file-truename)
-                                (file-name-directory))))
-    (delete-region (- (point) (length title)) (point))
-    (insert (format "[[file:%s][%s]]"
-                    (if current-file-path
-                        (file-relative-name path current-file-path)
-                      path)
-                    (org-roam--format-link-title title)))))
+If roam links are the default specified by `org-roam-use-roam-links', then it
+will delete the inserted TITLE and replace it with a complete roam link.
+
+If completing with the point inside of roam link syntax, [[roam:]], it
+will simply finish the TITLE and move the point forward out of the link
+regardless of the value of `org-roam-use-roam-links'."
+  (cond ((string= "roam" (org-element-property :type (org-element-context)))
+         (goto-char (org-element-property :end (org-element-context))))
+        (org-roam-use-roam-links
+         (delete-region (- (point) (length title)) (point))
+         (insert (format "[[roam:%s]]" title)))
+        (t (let* ((cache (gethash (file-truename org-roam-directory) company-org-roam-cache))
+                  (path (gethash title cache))
+                  (current-file-path (-> (or (buffer-base-buffer)
+                                             (current-buffer))
+                                         (buffer-file-name)
+                                         (file-truename)
+                                         (file-name-directory))))
+             (delete-region (- (point) (length title)) (point))
+             (insert (format "[[file:%s][%s]]"
+                             (if current-file-path
+                                 (file-relative-name path current-file-path)
+                               path)
+                             (org-roam--format-link-title title)))))))
 
 (defun company-org-roam--filter-candidates (prefix candidates)
   "Filter CANDIDATES that start with PREFIX.
@@ -129,10 +139,18 @@ Entries with no title do not appear in the completions."
     titles))
 
 (defun company-org-roam--get-candidates (prefix)
-  "Get the candidates for PREFIX."
-  (->> (company-org-roam--cache-get-titles)
-       (-flatten)
-       (company-org-roam--filter-candidates prefix)))
+  "Get the candidates for PREFIX.
+If completing roam-link, add existing roam-link TITLEs from current
+buffer as possible candidates."
+  (let ((roam-candidates
+         (if (or (string= "roam" (org-element-property :type (org-element-context)))
+                 org-roam-use-roam-links)
+             (org-roam--current-buffer-roam-link-titles)
+           nil)))
+    (->> (company-org-roam--cache-get-titles)
+         (-flatten)
+         (-union roam-candidates)
+         (company-org-roam--filter-candidates prefix))))
 
 ;;;###autoload
 (defun company-org-roam (command &optional arg &rest _)

--- a/company-org-roam.el
+++ b/company-org-roam.el
@@ -145,8 +145,8 @@ Entries with no title do not appear in the completions."
 If completing roam-link, add existing roam-link TITLEs from current
 buffer as possible candidates."
   (let ((roam-candidates
-         (if (or (string= "roam" (org-element-property :type (org-element-context)))
-                 org-roam-use-roam-links)
+         (if (or org-roam-use-roam-links
+         (string= "roam" (org-element-property :type (org-element-context))))
              (org-roam--current-buffer-roam-link-titles)
            nil)))
     (->> (company-org-roam--cache-get-titles)

--- a/company-org-roam.el
+++ b/company-org-roam.el
@@ -146,7 +146,7 @@ If completing roam-link, add existing roam-link TITLEs from current
 buffer as possible candidates."
   (let ((roam-candidates
          (if (or org-roam-use-roam-links
-         (string= "roam" (org-element-property :type (org-element-context))))
+                 (string= "roam" (org-element-property :type (org-element-context))))
              (org-roam--current-buffer-roam-link-titles)
            nil)))
     (->> (company-org-roam--cache-get-titles)

--- a/company-org-roam.el
+++ b/company-org-roam.el
@@ -85,7 +85,6 @@ then it will delete the inserted TITLE and replace it with a complete roam link.
 If completing with the point inside of roam link syntax, [[roam:]], it
 will simply finish the TITLE and move the point forward out of the link
 regardless of the value of `org-roam-link-use-roam-links'."
-  (message "Hello!!")
   (cond ((string= "roam" (org-element-property :type (org-element-context)))
          (goto-char (org-element-property :end (org-element-context))))
         (org-roam-link-use-roam-links

--- a/company-org-roam.el
+++ b/company-org-roam.el
@@ -42,6 +42,7 @@
 
 (defvar org-roam-directory)
 (defvar org-roam-use-roam-links)
+(declare-function org-roam--current-buffer-roam-link-titles "org-roam" ())
 
 (defgroup company-org-roam nil
   "Company completion backend for Org-roam."

--- a/company-org-roam.el
+++ b/company-org-roam.el
@@ -38,11 +38,12 @@
 (require 'cl-lib)
 (require 'company)
 (require 'org-roam)
+(require 'org-roam-link)
 (require 'dash)
 
 (defvar org-roam-directory)
-(defvar org-roam-use-roam-links)
-(declare-function org-roam--current-buffer-roam-link-titles "org-roam" ())
+(defvar org-roam-link-use-roam-links)
+(declare-function org-roam-link--current-buffer-roam-link-titles "org-roam-link" ())
 
 (defgroup company-org-roam nil
   "Company completion backend for Org-roam."
@@ -78,18 +79,20 @@ If completing an org file link, it deletes the inserted TITLE, and
 replaces it with a relative file link.  The completion inserts the
 absolute file path where the buffer does not have a corresponding file.
 
-If roam links are the default specified by `org-roam-use-roam-links', then it
-will delete the inserted TITLE and replace it with a complete roam link.
+If roam links are the default specified by `org-roam-link-use-roam-links',
+then it will delete the inserted TITLE and replace it with a complete roam link.
 
 If completing with the point inside of roam link syntax, [[roam:]], it
 will simply finish the TITLE and move the point forward out of the link
-regardless of the value of `org-roam-use-roam-links'."
+regardless of the value of `org-roam-link-use-roam-links'."
+  (message "Hello!!")
   (cond ((string= "roam" (org-element-property :type (org-element-context)))
          (goto-char (org-element-property :end (org-element-context))))
-        (org-roam-use-roam-links
+        (org-roam-link-use-roam-links
          (delete-region (- (point) (length title)) (point))
          (insert (format "[[roam:%s]]" title)))
-        (t (let* ((cache (gethash (file-truename org-roam-directory) company-org-roam-cache))
+        (t (let* ((cache (gethash (file-truename org-roam-directory)
+                                  company-org-roam-cache))
                   (path (gethash title cache))
                   (current-file-path (-> (or (buffer-base-buffer)
                                              (current-buffer))
@@ -146,8 +149,8 @@ If completing roam-link, add existing roam-link TITLEs from current
 buffer as possible candidates."
   (let ((roam-candidates
          (if (or (string= "roam" (org-element-property :type (org-element-context)))
-                 org-roam-use-roam-links)
-             (org-roam--current-buffer-roam-link-titles)
+                 org-roam-link-use-roam-links)
+             (org-roam-link--current-buffer-roam-link-titles)
            nil)))
     (->> (company-org-roam--cache-get-titles)
          (-flatten)

--- a/company-org-roam.el
+++ b/company-org-roam.el
@@ -41,6 +41,7 @@
 (require 'dash)
 
 (defvar org-roam-directory)
+(defvar org-roam-use-roam-links)
 
 (defgroup company-org-roam nil
   "Company completion backend for Org-roam."
@@ -73,7 +74,7 @@ A value of nil means the caches never expire."
 (defun company-org-roam--post-completion (title)
   "The post-completion action for `company-org-roam'.
 If completing an org file link, it deletes the inserted TITLE, and
-replaces it with a relative file link. The completion inserts the
+replaces it with a relative file link.  The completion inserts the
 absolute file path where the buffer does not have a corresponding file.
 
 If roam links are the default specified by `org-roam-use-roam-links', then it


### PR DESCRIPTION
For org-roam/org-roam#592

- Add conditional to company-org-roam--get-candidates to check if
  completion is for a roam-link or not.
  If completion is for a roam-link, include in-buffer candidates for
  TITLEs that are not part of the org-roam database yet
- Add conditional to company-org-roam--post-completion to check if
  completion is for a roam-link or not.
  If completion is for a roam-link either insert plain
  TITLE (completion inside `[[roam:]]` syntax) or insert complete roam
  link (`org-roam-use-roam-links` is `t`)

